### PR TITLE
added new funtions

### DIFF
--- a/pysnippets/list/list_manipulation.py
+++ b/pysnippets/list/list_manipulation.py
@@ -14,12 +14,6 @@ class ListManipulator:
     def remove_duplicates(lst: List[Any]) -> List[Any]:
         """
         Removes duplicate elements from the list while maintaining the original order.
-
-        Args:
-            lst (List[Any]): A list from which to remove duplicates.
-
-        Returns:
-            List[Any]: A list without duplicates.
         """
         seen = set()
         return [x for x in lst if not (x in seen or seen.add(x))]
@@ -28,12 +22,6 @@ class ListManipulator:
     def flatten_nested_list(nested_list: List[List[Any]]) -> List[Any]:
         """
         Flattens a nested list into a single list.
-
-        Args:
-            nested_list (List[List[Any]]): A nested list to flatten.
-
-        Returns:
-            List[Any]: A flattened list.
         """
         return [item for sublist in nested_list for item in sublist]
 
@@ -41,13 +29,6 @@ class ListManipulator:
     def list_intersection(lst1: List[Any], lst2: List[Any]) -> List[Any]:
         """
         Finds the intersection of two lists.
-
-        Args:
-            lst1 (List[Any]): The first list.
-            lst2 (List[Any]): The second list.
-
-        Returns:
-            List[Any]: The intersection of the two lists.
         """
         return list(set(lst1) & set(lst2))
 
@@ -55,12 +36,6 @@ class ListManipulator:
     def random_shuffle(lst: List[Any]) -> List[Any]:
         """
         Randomly shuffles the elements of the list.
-
-        Args:
-            lst (List[Any]): A list to shuffle.
-
-        Returns:
-            List[Any]: A shuffled list (order will vary).
         """
         import random
         random.shuffle(lst)
@@ -80,6 +55,52 @@ class ListManipulator:
         frequency = Counter(lst)
         return sorted(lst, key=lambda x: frequency[x], reverse=True)
 
+    @staticmethod
+    def chunk_list(lst: List[Any], chunk_size: int) -> List[List[Any]]:
+        """
+        Splits a list into smaller chunks of a given size.
+        """
+        return [lst[i:i + chunk_size] for i in range(0, len(lst), chunk_size)]
+
+    @staticmethod
+    def most_frequent_element(lst: List[Any]) -> Any:
+        """
+        Identifies the most frequently occurring element in a list.
+        """
+        if not lst:
+            return None
+        return Counter(lst).most_common(1)[0][0]
+
+    @staticmethod
+    def rotate_list(lst: List[Any], positions: int) -> List[Any]:
+        """
+        Rotates the list by a given number of positions.
+        """
+        positions %= len(lst)
+        return lst[-positions:] + lst[:-positions]
+
+    @staticmethod
+    def unique_elements(lst: List[Any]) -> List[Any]:
+        """
+        Gets elements that appear exactly once in the list.
+        """
+        frequency = Counter(lst)
+        return [x for x in lst if frequency[x] == 1]
+
+    @staticmethod
+    def find_pairs_with_sum(lst: List[int], target: int) -> List[tuple]:
+        """
+        Finds all pairs of numbers that sum to a specific target.
+        """
+        seen = set()
+        pairs = []
+        for num in lst:
+            complement = target - num
+            if complement in seen:
+                pairs.append((complement, num))
+            seen.add(num)
+        return pairs
+
 # Example usage of the functions in the script
 if __name__ == "__main__":
     sample_list = [1, 2, 2, 3, 4, 4, 5, 5, 5]
@@ -91,4 +112,8 @@ if __name__ == "__main__":
     logging.info("List Intersection: %s", ListManipulator.list_intersection([1, 2, 3], [2, 3, 4]))
     logging.info("Shuffled List: %s", ListManipulator.random_shuffle(sample_list.copy()))  # Using copy to keep original
     logging.info("Sorted by Frequency: %s", ListManipulator.sort_by_frequency(sample_list))
-
+    logging.info("Chunked List: %s", ListManipulator.chunk_list(sample_list, 2))
+    logging.info("Most Frequent Element: %s", ListManipulator.most_frequent_element(sample_list))
+    logging.info("Rotated List: %s", ListManipulator.rotate_list(sample_list, 2))
+    logging.info("Unique Elements: %s", ListManipulator.unique_elements(sample_list))
+    logging.info("Pairs with Sum 6: %s", ListManipulator.find_pairs_with_sum(sample_list, 6))

--- a/pysnippets/list/test_list_manipulation.py
+++ b/pysnippets/list/test_list_manipulation.py
@@ -23,5 +23,25 @@ class TestListManipulator(unittest.TestCase):
         self.assertEqual(ListManipulator.sort_by_frequency([4, 5, 6, 4, 5, 4]), [4, 4, 4, 5, 5, 6])
         self.assertEqual(ListManipulator.sort_by_frequency([1, 2, 2, 3, 3, 3]), [3, 3, 3, 2, 2, 1])
 
+    def test_chunk_list(self):
+        self.assertEqual(ListManipulator.chunk_list([1, 2, 3, 4, 5, 6], 2), [[1, 2], [3, 4], [5, 6]])
+        self.assertEqual(ListManipulator.chunk_list([1, 2, 3, 4, 5], 3), [[1, 2, 3], [4, 5]])
+
+    def test_most_frequent_element(self):
+        self.assertEqual(ListManipulator.most_frequent_element([1, 2, 2, 3, 3, 3]), 3)
+        self.assertIsNone(ListManipulator.most_frequent_element([]))
+
+    def test_rotate_list(self):
+        self.assertEqual(ListManipulator.rotate_list([1, 2, 3, 4, 5], 2), [4, 5, 1, 2, 3])
+        self.assertEqual(ListManipulator.rotate_list([1, 2, 3, 4, 5], 5), [1, 2, 3, 4, 5])
+
+    def test_unique_elements(self):
+        self.assertEqual(ListManipulator.unique_elements([1, 2, 2, 3, 3, 4]), [1, 4])
+        self.assertEqual(ListManipulator.unique_elements([1, 1, 1, 2]), [2])
+
+    def test_find_pairs_with_sum(self):
+        self.assertEqual(ListManipulator.find_pairs_with_sum([1, 2, 3, 4, 5], 6), [(2, 4), (1, 5)])
+        self.assertEqual(ListManipulator.find_pairs_with_sum([1, 2, 3], 7), [])
+
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
fixes: #494 

This pull request includes several enhancements and refactoring of the `ListManipulator` class in the `pysnippets/list/list_manipulation.py` file, as well as updates to the corresponding test cases. The main changes involve adding new utility methods for list manipulation and removing redundant docstrings.

Enhancements and new utility methods:

* Added `chunk_list` method to split a list into smaller chunks of a given size.
* Added `most_frequent_element` method to identify the most frequently occurring element in a list.
* Added `rotate_list` method to rotate the list by a given number of positions.
* Added `unique_elements` method to get elements that appear exactly once in the list.
* Added `find_pairs_with_sum` method to find all pairs of numbers that sum to a specific target.

* Added test cases for the new methods `chunk_list`, `most_frequent_element`, `rotate_list`, `unique_elements`, and `find_pairs_with_sum` in `pysnippets/list/test_list_manipulation.py`.
* All test cases have been executed successfully, confirming the correctness of the changes. 